### PR TITLE
Fix social profile URL validation and auto-prefix protocol

### DIFF
--- a/src/components/dashboard/ProfileSection.tsx
+++ b/src/components/dashboard/ProfileSection.tsx
@@ -45,12 +45,8 @@ interface ProfileSectionProps {
     onEditClick?: () => void
 }
 
-const withProtocol = (url: string) => {
-    if (!url.startsWith("http://") && !url.startsWith("https://")) {
-        return `https://${url}`;
-    }
-    return url;
-};
+import {withProtocol} from "@/utils/url";
+
 
 const getInitials = (name: string) => {
     return name

--- a/src/components/modals/EditOnboardingModal.tsx
+++ b/src/components/modals/EditOnboardingModal.tsx
@@ -22,6 +22,7 @@ import {
     InterviewCategory,
     ExperienceLevel
 } from "@/types/onboarding";
+import {withProtocol} from "@/utils/url";
 
 interface EditOnboardingModalProps {
     isOpen: boolean
@@ -124,9 +125,9 @@ const EditOnboardingModal: React.FC<EditOnboardingModalProps> = ({
                 goal: formData.goal,
                 targetCompanies: formData.targetCompanies,
                 preferredCategories: formData.preferredCategories,
-                linkedInUrl: formData.linkedInUrl,
-                githubUrl: formData.githubUrl,
-                leetCodeUrl: formData.leetCodeUrl
+                linkedInUrl: withProtocol(formData.linkedInUrl),
+                githubUrl: withProtocol(formData.githubUrl),
+                leetCodeUrl: withProtocol(formData.leetCodeUrl)
             };
 
             const response = await fetch(

--- a/src/pages/journey/[username].tsx
+++ b/src/pages/journey/[username].tsx
@@ -13,6 +13,7 @@ import {
     CardHeader,
     CardTitle
 } from "@/components/ui/card";
+import {withProtocol} from "@/utils/url";
 
 interface PrepLog {
     _id: string
@@ -74,12 +75,8 @@ const PrepLogsShowcase = () => {
         return "Good evening";
     };
 
-    // Utility function to add protocol to URLs
-    function withProtocol(url: string | undefined) {
-        if (!url) {return undefined;}
+    // URL utility imported from @/utils/url
 
-        return url.startsWith("http") ? url : `https://${url}`;
-    }
 
     const handleGetStarted = () => {
         router.push("/auth");

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,16 @@
+/**
+ * Ensures a URL has a protocol (defaults to https:// if missing)
+ * @param url The URL string to normalize
+ * @returns The normalized URL string
+ */
+export const withProtocol = (url: string | undefined): string => {
+    if (!url || url.trim() === "") {
+        return "";
+    }
+    
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl.startsWith("http://") && !trimmedUrl.startsWith("https://")) {
+        return `https://${trimmedUrl}`;
+    }
+    return trimmedUrl;
+};


### PR DESCRIPTION
### Summary
Fixes overly strict social profile URL validation by normalizing URLs before submission.

### Changes
- Added a shared `withProtocol` utility to automatically prefix `https://` when missing
- Applied URL normalization for social profile fields during onboarding
- Removed duplicated URL-handling logic and reused the shared utility

### Verification
- Valid social URLs without protocol (e.g. `linkedin.com/in/username`) are now accepted
- URLs are correctly normalized before being sent to the backend

Closes #70
